### PR TITLE
카운드 애니메이션, 컨테이너 프로필 호버 위치 변경

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,30 +1,3 @@
-import Container from '@/components/container/Container';
-import { Gathering } from '@/types/types';
-
 export default function Home() {
-  const testData1: Gathering = {
-    teamId: 'FESI3-3',
-    id: 104,
-    type: 'WORKATION',
-    name: '워크케이션 모임',
-    dateTime: '2024-09-25T09:00:00Z',
-    registrationEnd: '2024-09-24T09:00:00Z',
-    location: '홍대입구',
-    participantCount: 10,
-    capacity: 20,
-    image: 'https://example.com/image4.jpg',
-    createdBy: 4,
-    canceledAt: null,
-  };
-
-  const testData2 = { ...testData1, id: 105 };
-  const testData3 = { ...testData1, id: 106 };
-
-  return (
-    <div className="flex flex-col gap-5 items-center">
-      <Container gatheringDetails={testData1} />
-      <Container gatheringDetails={testData2} />
-      <Container gatheringDetails={testData3} />
-    </div>
-  );
+  return <></>;
 }

--- a/components/animation/count/Count.tsx
+++ b/components/animation/count/Count.tsx
@@ -2,19 +2,24 @@
 import { useState, useEffect } from 'react';
 
 export default function CountAnimation(num: number) {
-  const [count, setCount] = useState(0);
+  const [count, setCount] = useState(1);
   const duration = 2000;
+  const frameRate = 1000 / 60; // 한 프레임의 시간
+  const totalFrame = duration / frameRate; // 전체 프레임
+  const increment = num / totalFrame;
 
   useEffect(() => {
+    let currentCount = 1;
     const counter = setInterval(() => {
       setCount((prevCount) => {
+        currentCount += increment;
         if (prevCount >= num) {
           clearInterval(counter);
           return num; // 목표에 도달하면 num으로 설정
         }
-        return prevCount + 1; // 증가
+        return Math.round(currentCount); // 증가
       });
-    }, duration / num);
+    }, frameRate);
   }, []);
 
   return count;

--- a/components/container/Container.test.tsx
+++ b/components/container/Container.test.tsx
@@ -19,23 +19,39 @@ const testGatheringData: Gathering = {
   canceledAt: null,
 };
 
+const participants = [
+  {
+    teamId: 'FESI3-3',
+    userId: 681,
+    gatheringId: 1100,
+    joinedAt: '2024-09-30T05:19:01.971Z',
+    User: {
+      id: 681,
+      email: 'acckr0604@gmail.com',
+      name: 'seongHoon',
+      companyName: 'test',
+      image: null,
+    },
+  },
+];
+
 describe('Container Component', () => {
   it('Container 컴포넌트 기본 렌더링', () => {
-    render(<Container gatheringDetails={testGatheringData} />);
+    render(<Container gatheringDetails={testGatheringData} participants={participants} />);
     // Check if the main title and location are rendered
-    expect(screen.getByText('워크케이션 모임')).toBeInTheDocument();
+    expect(screen.getByText('WORKATION')).toBeInTheDocument();
     expect(screen.getByText('홍대입구')).toBeInTheDocument();
   });
 
   it('참여자 5명 이상인 경우 "개설확정", "chekedIcon" 노출', () => {
-    render(<Container gatheringDetails={testGatheringData} />);
+    render(<Container gatheringDetails={testGatheringData} participants={participants} />);
 
     expect(screen.queryByTestId('checkIsOpen')).toBeInTheDocument();
   });
 
   it('참여자 5명 미만인 경우 "개설확정", "chekedIcon" 노출 안됨', () => {
     const newTestGatheringData = { ...testGatheringData, participantCount: 4 };
-    render(<Container gatheringDetails={newTestGatheringData} />);
+    render(<Container gatheringDetails={newTestGatheringData} participants={participants} />);
 
     expect(screen.queryByTestId('checkIsOpen')).not.toBeInTheDocument();
   });

--- a/components/container/Container.tsx
+++ b/components/container/Container.tsx
@@ -6,39 +6,24 @@ import Saved from '../animation/saved/Saved';
 import ExpandLine from '../animation/expandLine/ExpandLine';
 import Profile from '../profile/Profile';
 import { formatDateTime } from '@/utils/gathering';
-import { Gathering } from '@/types/types';
+import { Gathering, Participant } from '@/lib/definition';
 import CountAnimation from '../animation/count/Count';
 
 import VectorIcon from '/public/icons/Vector.svg';
 import CheckedIcon from '/public/icons/Checked.svg';
 
-type ParticipantInfo = {
-  teamId: string;
-  userId: number;
-  gatheringId: number;
-  joinedAt: string;
-  User: {
-    id: number;
-    email: string;
-    name: string;
-    companyName: string;
-    image: null | string;
-  };
+type Props = {
+  gatheringDetails: Gathering;
+  participants: Participant[];
 };
 
-export default function Container({ gatheringDetails }: { gatheringDetails: Gathering }) {
-  const [profileImages, setProfileImages] = useState<string[]>([]);
+export default function Container({ gatheringDetails, participants }: Props) {
+  const sortedParticipants = participants.sort((a, b) => {
+    const first = a.User.image !== null ? 1 : 0;
+    const second = b.User.image != null ? 1 : 0;
 
-  useEffect(() => {
-    /* 특정 모임의 참가자 목록 조회 API 요청하고 받은 데이터 아래 코드로 포맷 */
-    // const imageList = testParticipants
-    //   .map((data) => data.User.image)
-    //   .filter((image) => image !== null);
-    // while (imageList.length < gatheringDetails.participantCount) {
-    //   imageList.push('defaultProfile');
-    // }
-    // setProfileImages(imageList);
-  }, []);
+    return second - first;
+  });
 
   return (
     <div className="w-347pxr h-244pxr md:w-344pxr lg:w-490pxr lg:h-274pxr py-6 border-2 border-gray-200 rounded-3xl">
@@ -47,7 +32,7 @@ export default function Container({ gatheringDetails }: { gatheringDetails: Gath
           <div className="flex px-6 justify-between">
             <div className="flex flex-col gap-3">
               <div className="flex flex-col gap-0.5">
-                <span className="text-lg font-semibold ">{gatheringDetails.name}</span>
+                <span className="text-lg font-semibold ">{gatheringDetails.type}</span>
                 <span className="text-sm font-medium max-w-211pxr lg:max-w-374pxr">
                   {gatheringDetails.location}
                 </span>
@@ -63,7 +48,7 @@ export default function Container({ gatheringDetails }: { gatheringDetails: Gath
             </div>
             <Saved gatheringId={gatheringDetails.id} />
           </div>
-          <VectorIcon className="w-full h-1/2" />
+          <VectorIcon className="w-full" />
         </div>
         <div className="px-6 flex flex-col gap-2">
           <div className="flex flex-col gap-3">
@@ -71,45 +56,52 @@ export default function Container({ gatheringDetails }: { gatheringDetails: Gath
               <div className="flex gap-3 items-center">
                 <div className="flex gap-1.5 text-sm font-semibold">
                   <span>모집 정원</span>
-                  <span>{CountAnimation(gatheringDetails.participantCount)}명</span>
+                  <span>
+                    {gatheringDetails.participantCount === 0
+                      ? '0'
+                      : CountAnimation(gatheringDetails.participantCount)}{' '}
+                    명
+                  </span>
                 </div>
                 {/* profile images */}
                 <div className="group relative flex -space-x-2.5">
-                  {profileImages.map((profile, i) => {
+                  {sortedParticipants.slice(0, 4).map((data, i) => {
+                    const profile = data.User.image;
                     return (
                       <div key={i}>
-                        {i < 4 && (
-                          <Profile
-                            usedIn="container"
-                            image={profile === 'defaultProfile' ? null : profile}
-                          />
-                        )}
+                        <Profile
+                          usedIn="container"
+                          image={profile === 'defaultProfile' ? null : profile}
+                        />
                       </div>
                     );
                   })}
                   {gatheringDetails.participantCount > 4 && (
-                    <div className="w-29pxr h-29pxr flex items-center justify-center bg-gray-100 rounded-full -ml-2.5">
-                      <span
-                        className="text-sm font-semibold
+                    <>
+                      <div className="w-29pxr h-29pxr flex items-center justify-center bg-gray-100 rounded-full">
+                        <span
+                          className="text-sm font-semibold
                  text-gray-800"
-                      >
-                        +{gatheringDetails.participantCount - 4}
-                      </span>
-                    </div>
+                        >
+                          +{gatheringDetails.participantCount - 4}
+                        </span>
+                      </div>
+                      <div className="absolute hidden group-hover:block z-10 bottom-29pxr left-50pxr w-150pxr p-2 rounded-md max-h-70pxr lg:max-h-120pxr bg-gray-50 overflow-y-auto scrollbar">
+                        <div className="grid grid-cols-4 gap-1">
+                          {sortedParticipants.map((data, i) => {
+                            const profile = data.User.image;
+                            return (
+                              <Profile
+                                key={i}
+                                usedIn="container"
+                                image={profile === 'defaultProfile' ? null : profile}
+                              />
+                            );
+                          })}
+                        </div>
+                      </div>
+                    </>
                   )}
-                  <div className="absolute hidden group-hover:block z-10 top-28pxr w-150pxr p-2 rounded-md min-h-10 max-h-120pxr bg-gray-50 overflow-y-auto scrollbar">
-                    <div className="grid grid-cols-4 gap-1">
-                      {profileImages.map((profile, i) => {
-                        return (
-                          <Profile
-                            key={i}
-                            usedIn="container"
-                            image={profile === 'defaultProfile' ? null : profile}
-                          />
-                        );
-                      })}
-                    </div>
-                  </div>
                 </div>
               </div>
               {gatheringDetails.participantCount >= 5 && (

--- a/lib/definition.ts
+++ b/lib/definition.ts
@@ -39,3 +39,17 @@ export type Review = {
     image: string;
   };
 };
+
+export type Participant = {
+  teamId: string;
+  userId: number;
+  gatheringId: number;
+  joinedAt: string;
+  User: {
+    id: number;
+    email: string;
+    name: string;
+    companyName: string;
+    image: string | null;
+  };
+};

--- a/public/icons/Vector.svg
+++ b/public/icons/Vector.svg
@@ -1,3 +1,3 @@
-<svg height="2" viewBox="0 0 948 2" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0 1L948 1.00008" stroke="#E5E7EB" stroke-width="2" stroke-dasharray="4 4"/>
+<svg xmlns="http://www.w3.org/2000/svg" height="2" viewBox="0 0 486 2" fill="none">
+  <path d="M0 1H486" stroke="#E5E7EB" stroke-width="2" stroke-dasharray="4 4"/>
 </svg>


### PR DESCRIPTION
## #️⃣연관된 trello 작업

- 카운트 애니메이션 오류 수정
- 컨테이너 프로필 호버 위치 변경

## 🔎 작업 내용
-  카운드 애니메이션 동작시 2의 배수로 카운드 되는 오류 수정
-  프로필 이미지 호버시 기존 텍스트를 부분적으로 가리는 경우가 있어 기존 텍스트가 가려지지 않도록 수정

  <br/>

## 📸 이미지 첨부

- 카운드 애니메이션 수정 전
![preCountAnimation](https://github.com/user-attachments/assets/37d75ac6-332e-40c2-a73a-179f0ae66255)

- 카운트 애니메이션 수정 후
![currCountAnimation](https://github.com/user-attachments/assets/713ea973-17d4-403d-8037-ee28539941df)

- 프로필 호버 수정 전
![containerhover](https://github.com/user-attachments/assets/2676f1e5-2438-49a3-bfbb-e1e8872f9fec)


- 프로필 호버 수정 후
![스크린샷 2024-10-01 163535](https://github.com/user-attachments/assets/ff1b1724-1689-412c-acd5-14f8fcfd79d7)
![스크린샷 2024-10-01 163547](https://github.com/user-attachments/assets/615d1300-25b9-4778-9bfa-9ab60d2b76cc)

<br/>

## 💬리뷰 요구사항(선택)

